### PR TITLE
remove repo name from homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "http://camclark1995.github.io/porosity-calc",
+  "homepage": "http://camclark1995.github.io",
   "name": "porosity-calc",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
This makes it work on custom domain, but NOT on github pages. dumb